### PR TITLE
fix: 解析非tab隔断键值对失败

### DIFF
--- a/vdf2json.go
+++ b/vdf2json.go
@@ -33,6 +33,9 @@ func ToJson(vdfData string) string {
 		if strings.Contains(line, "\"\t\t\"") {
 			line = strings.Replace(line, "\"\t\t\"", "\": \"", -1)
 			line += ","
+		} else if strings.Contains(line, "\" \"") {
+			line = strings.Replace(line, "\" \"", "\": \"", -1)
+			line += ","
 		}
 		line = strings.Replace(line, "{", ": {", -1)
 		line = strings.Replace(line, "\t", "", -1)


### PR DESCRIPTION
for CSGO Toolbox